### PR TITLE
Wrong variable name and case sensitive filenames

### DIFF
--- a/onboard-1.sh
+++ b/onboard-1.sh
@@ -6,7 +6,7 @@
 cluster_name="mycluster"
 
 # namespace for CloudGuard (default is checkpoint) 
-namespace="checkpoint"
+myns="checkpoint"
 
 # Your CloudGuard API Key and Secret
 CHKP_CLOUDGUARD_API="your-cloudguard-api"
@@ -40,7 +40,7 @@ oc create serviceaccount cp-resource-management --namespace $myns
 echo Service Account "${myns}" has been created. 
 
 #Create Admin User. Make sure uid1000.json is in the same directory.
-oc create -f uid1000.json --as system:admin
+oc create -f UID1000.json --as system:admin
 
 # Policy Add User
 oc adm policy add-scc-to-user uid1000 -z cp-resource-management --as system:admin


### PR DESCRIPTION
The variabel namespace defined in line 9 is unused. You use a different variable name in the script ( lines 24, 30, 35, 38), which is always an empty string, because it is never defined before.

Additionally you refer to a file uid1000.json, which does not exist on a case-sensitive filesystem, as the filename is UID1000.json.